### PR TITLE
Fix number ranges using `..`

### DIFF
--- a/patcher.py
+++ b/patcher.py
@@ -72,6 +72,7 @@ NUM_DIGIT_COPIES = 7
 def gen_feature(digit_names, underscore_name, dot_name, do_decimals):
     if do_decimals:
         decimal_sub = """
+    ignore sub {dot_name} {dot_name} @digits';
     sub {dot_name} @digits' by @nd2;
     sub @nd2 @digits' by @nd1;
     sub @nd1 @digits' by @nd6;


### PR DESCRIPTION
Avoid dropping into the decimal rule for digits following `..`, because that's a range, not a decimal point.

Fixes #9, mostly.  It's not quite right because it causes the first digit after the `..` to not be underlined when it should, but it's at least more accurate overall.